### PR TITLE
createCalendar custom account and retrieveCalendar account filter

### DIFF
--- a/android/src/main/kotlin/sncf/connect/tech/eventide/CalendarApi.g.kt
+++ b/android/src/main/kotlin/sncf/connect/tech/eventide/CalendarApi.g.kt
@@ -56,7 +56,7 @@ class FlutterError (
  * [color] is the color of the calendar.
  *
  * [isWritable] is a boolean to indicate if the calendar is writable.
- * 
+ *
  * [account] is the account the calendar belongs to
  * TODO: explain android/ios differences
  *
@@ -220,7 +220,7 @@ private open class CalendarApiPigeonCodec : StandardMessageCodec() {
 interface CalendarApi {
   fun requestCalendarPermission(callback: (Result<Boolean>) -> Unit)
   fun createCalendar(title: String, color: Long, account: Account?, callback: (Result<Calendar>) -> Unit)
-  fun retrieveCalendars(onlyWritableCalendars: Boolean, callback: (Result<List<Calendar>>) -> Unit)
+  fun retrieveCalendars(onlyWritableCalendars: Boolean, from: Account?, callback: (Result<List<Calendar>>) -> Unit)
   fun deleteCalendar(calendarId: String, callback: (Result<Unit>) -> Unit)
   fun createEvent(calendarId: String, title: String, startDate: Long, endDate: Long, isAllDay: Boolean, description: String?, url: String?, callback: (Result<Event>) -> Unit)
   fun retrieveEvents(calendarId: String, startDate: Long, endDate: Long, callback: (Result<List<Event>>) -> Unit)
@@ -283,7 +283,8 @@ interface CalendarApi {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val onlyWritableCalendarsArg = args[0] as Boolean
-            api.retrieveCalendars(onlyWritableCalendarsArg) { result: Result<List<Calendar>> ->
+            val fromArg = args[1] as Account?
+            api.retrieveCalendars(onlyWritableCalendarsArg, fromArg) { result: Result<List<Calendar>> ->
               val error = result.exceptionOrNull()
               if (error != null) {
                 reply.reply(wrapError(error))

--- a/android/src/main/kotlin/sncf/connect/tech/eventide/CalendarImplem.kt
+++ b/android/src/main/kotlin/sncf/connect/tech/eventide/CalendarImplem.kt
@@ -14,8 +14,8 @@ class CalendarImplem(
     private var permissionHandler: PermissionHandler,
     private var calendarContentUri: Uri = CalendarContract.Calendars.CONTENT_URI,
     private var eventContentUri: Uri = CalendarContract.Events.CONTENT_URI,
-    private var remindersContentUri: Uri = CalendarContract.Reminders.CONTENT_URI,
-    ): CalendarApi {
+    private var remindersContentUri: Uri = CalendarContract.Reminders.CONTENT_URI
+): CalendarApi {
     override fun requestCalendarPermission(callback: (Result<Boolean>) -> Unit) {
         permissionHandler.requestWritePermission { granted ->
             callback(Result.success(granted))
@@ -25,20 +25,22 @@ class CalendarImplem(
     override fun createCalendar(
         title: String,
         color: Long,
+        account: Account?,
         callback: (Result<Calendar>) -> Unit
     ) {
         permissionHandler.requestWritePermission { granted ->
             if (granted) {
                 CoroutineScope(Dispatchers.IO).launch {
                     try {
+                        val resolvedAccount = account ?: Account("eventide", CalendarContract.ACCOUNT_TYPE_LOCAL)
                         val values = ContentValues().apply {
-                            put(CalendarContract.Calendars.ACCOUNT_NAME, "account_name")
-                            put(CalendarContract.Calendars.ACCOUNT_TYPE, CalendarContract.ACCOUNT_TYPE_LOCAL)
+                            put(CalendarContract.Calendars.ACCOUNT_NAME, resolvedAccount.name)
+                            put(CalendarContract.Calendars.ACCOUNT_TYPE, resolvedAccount.type)
                             put(CalendarContract.Calendars.NAME, title)
                             put(CalendarContract.Calendars.CALENDAR_DISPLAY_NAME, title)
                             put(CalendarContract.Calendars.CALENDAR_COLOR, color)
                             put(CalendarContract.Calendars.CALENDAR_ACCESS_LEVEL, CalendarContract.Calendars.CAL_ACCESS_OWNER)
-                            put(CalendarContract.Calendars.OWNER_ACCOUNT, "owner_account")
+                            put(CalendarContract.Calendars.OWNER_ACCOUNT, resolvedAccount.name)
                             put(CalendarContract.Calendars.VISIBLE, 1)
                             put(CalendarContract.Calendars.SYNC_EVENTS, 1)
                         }
@@ -46,15 +48,21 @@ class CalendarImplem(
                         val uri = calendarContentUri
                             .buildUpon()
                             .appendQueryParameter(CalendarContract.CALLER_IS_SYNCADAPTER, "true")
-                            .appendQueryParameter(CalendarContract.Calendars.ACCOUNT_NAME, "account_name")
-                            .appendQueryParameter(CalendarContract.Calendars.ACCOUNT_TYPE, CalendarContract.ACCOUNT_TYPE_LOCAL)
+                            .appendQueryParameter(CalendarContract.Calendars.ACCOUNT_NAME, resolvedAccount.name)
+                            .appendQueryParameter(CalendarContract.Calendars.ACCOUNT_TYPE, resolvedAccount.type)
                             .build()
 
                         val calendarUri = contentResolver.insert(uri, values)
                         if (calendarUri != null) {
                             val calendarId = calendarUri.lastPathSegment?.toLong()
                             if (calendarId != null) {
-                                val calendar = Calendar(calendarId.toString(), title, color, isWritable = true, CalendarContract.ACCOUNT_TYPE_LOCAL)
+                                val calendar = Calendar(
+                                    id = calendarId.toString(),
+                                    title = title,
+                                    color = color,
+                                    isWritable = true,
+                                    account = resolvedAccount
+                                )
                                 callback(Result.success(calendar))
                             } else {
                                 callback(Result.failure(
@@ -103,7 +111,8 @@ class CalendarImplem(
                             CalendarContract.Calendars.CALENDAR_DISPLAY_NAME,
                             CalendarContract.Calendars.CALENDAR_COLOR,
                             CalendarContract.Calendars.CALENDAR_ACCESS_LEVEL,
-                            CalendarContract.Calendars.ACCOUNT_NAME
+                            CalendarContract.Calendars.ACCOUNT_NAME,
+                            CalendarContract.Calendars.ACCOUNT_TYPE
                         )
                         val selection = if (onlyWritableCalendars) ("(" + CalendarContract.Calendars.CALENDAR_ACCESS_LEVEL + " >=  ?)") else null
                         val selectionArgs = if (onlyWritableCalendars) arrayOf(CalendarContract.Calendars.CAL_ACCESS_CONTRIBUTOR.toString()) else null
@@ -117,14 +126,18 @@ class CalendarImplem(
                                 val displayName = it.getString(it.getColumnIndexOrThrow(CalendarContract.Calendars.CALENDAR_DISPLAY_NAME))
                                 val color = it.getLong(it.getColumnIndexOrThrow(CalendarContract.Calendars.CALENDAR_COLOR))
                                 val accessLevel = it.getInt(it.getColumnIndexOrThrow(CalendarContract.Calendars.CALENDAR_ACCESS_LEVEL))
-                                val sourceName = it.getString(it.getColumnIndexOrThrow(CalendarContract.Calendars.ACCOUNT_NAME))
+                                val accountName = it.getString(it.getColumnIndexOrThrow(CalendarContract.Calendars.ACCOUNT_NAME))
+                                val accountType = it.getString(it.getColumnIndexOrThrow(CalendarContract.Calendars.ACCOUNT_TYPE))
 
                                 val calendar = Calendar(
                                     id = id,
                                     title = displayName,
                                     color = color,
                                     isWritable = accessLevel >= CalendarContract.Calendars.CAL_ACCESS_CONTRIBUTOR,
-                                    sourceName = sourceName
+                                    account = Account(
+                                        name = accountName,
+                                        type = accountType
+                                    )
                                 )
 
                                 calendars.add(calendar)

--- a/android/src/test/kotlin/sncf/connect/tech/eventide/CalendarImplemTest.kt
+++ b/android/src/test/kotlin/sncf/connect/tech/eventide/CalendarImplemTest.kt
@@ -86,7 +86,7 @@ class CalendarImplemTest {
 
         var result: Result<Calendar>? = null
         val latch = CountDownLatch(1)
-        calendarImplem.createCalendar("Test Calendar", 0xFF0000) {
+        calendarImplem.createCalendar("Test Calendar", 0xFF0000, Account("1", "Test Account")) {
             result = it
             latch.countDown()
         }
@@ -104,7 +104,7 @@ class CalendarImplemTest {
         }
 
         var result: Result<Calendar>? = null
-        calendarImplem.createCalendar("Test Calendar", 0xFF0000) {
+        calendarImplem.createCalendar("Test Calendar", 0xFF0000, null) {
             result = it
         }
 
@@ -120,7 +120,7 @@ class CalendarImplemTest {
 
         var result: Result<Calendar>? = null
         val latch = CountDownLatch(1)
-        calendarImplem.createCalendar("Test Calendar", 0xFF0000) {
+        calendarImplem.createCalendar("Test Calendar", 0xFF0000, null) {
             result = it
             latch.countDown()
         }
@@ -141,7 +141,7 @@ class CalendarImplemTest {
 
         var result: Result<Calendar>? = null
         val latch = CountDownLatch(1)
-        calendarImplem.createCalendar("Test Calendar", 0xFF0000) {
+        calendarImplem.createCalendar("Test Calendar", 0xFF0000, null) {
             result = it
             latch.countDown()
         }

--- a/example/ios/EventideTests/CalendarImplemTests.swift
+++ b/example/ios/EventideTests/CalendarImplemTests.swift
@@ -91,7 +91,7 @@ final class CalendarImplemTests: XCTestCase {
             permissionHandler: PermissionGranted()
         )
         
-        calendarImplem.createCalendar(title: "title", color: 0xFF0000) { createCalendarResult in
+        calendarImplem.createCalendar(title: "title", color: 0xFF0000, account: Account(name: "local", type: "local")) { createCalendarResult in
             switch (createCalendarResult) {
             case .success(let calendar):
                 XCTAssert(calendar.title == "title")
@@ -116,7 +116,7 @@ final class CalendarImplemTests: XCTestCase {
                     title: "title",
                     color: UIColor.red,
                     isWritable: false,
-                    sourceName: "local",
+                    account: Account(name: "local", type: "local"),
                     events: []
                 ),
                 MockCalendar(
@@ -124,7 +124,7 @@ final class CalendarImplemTests: XCTestCase {
                     title: "title",
                     color: UIColor.blue,
                     isWritable: true,
-                    sourceName: "iCloud",
+                    account: Account(name: "iCloud", type: "calDAV"),
                     events: []
                 )
             ]
@@ -159,7 +159,7 @@ final class CalendarImplemTests: XCTestCase {
                     title: "title",
                     color: UIColor.red,
                     isWritable: false,
-                    sourceName: "local",
+                    account: Account(name: "local", type: "local"),
                     events: []
                 ),
                 MockCalendar(
@@ -167,7 +167,7 @@ final class CalendarImplemTests: XCTestCase {
                     title: "title",
                     color: UIColor.blue,
                     isWritable: true,
-                    sourceName: "iCloud",
+                    account: Account(name: "iCloud", type: "calDAV"),
                     events: []
                 )
             ]
@@ -203,7 +203,7 @@ final class CalendarImplemTests: XCTestCase {
                     title: "title",
                     color: UIColor.red,
                     isWritable: true,
-                    sourceName: "local",
+                    account: Account(name: "local", type: "local"),
                     events: []
                 )
             ]
@@ -237,7 +237,7 @@ final class CalendarImplemTests: XCTestCase {
                     title: "title",
                     color: UIColor.red,
                     isWritable: false,
-                    sourceName: "local",
+                    account: Account(name: "local", type: "local"),
                     events: []
                 )
             ]
@@ -276,7 +276,7 @@ final class CalendarImplemTests: XCTestCase {
                     title: "title",
                     color: UIColor.red,
                     isWritable: false,
-                    sourceName: "local",
+                    account: Account(name: "local", type: "local"),
                     events: []
                 )
             ]
@@ -318,7 +318,7 @@ final class CalendarImplemTests: XCTestCase {
                     title: "title",
                     color: UIColor.red,
                     isWritable: true,
-                    sourceName: "local",
+                    account: Account(name: "local", type: "local"),
                     events: []
                 )
             ]
@@ -366,7 +366,7 @@ final class CalendarImplemTests: XCTestCase {
                     title: "title",
                     color: UIColor.red,
                     isWritable: true,
-                    sourceName: "local",
+                    account: Account(name: "local", type: "local"),
                     events: []
                 )
             ]
@@ -415,7 +415,7 @@ final class CalendarImplemTests: XCTestCase {
                     title: "title",
                     color: UIColor.red,
                     isWritable: true,
-                    sourceName: "local",
+                    account: Account(name: "local", type: "local"),
                     events: [
                         MockEvent(
                             id: "1",
@@ -479,7 +479,7 @@ final class CalendarImplemTests: XCTestCase {
                     title: "title",
                     color: UIColor.red,
                     isWritable: true,
-                    sourceName: "local",
+                    account: Account(name: "local", type: "local"),
                     events: [
                         MockEvent(
                             id: "1",
@@ -532,7 +532,7 @@ final class CalendarImplemTests: XCTestCase {
                     title: "title",
                     color: UIColor.red,
                     isWritable: true,
-                    sourceName: "local",
+                    account: Account(name: "local", type: "local"),
                     events: [
                         MockEvent(
                             id: "1",
@@ -577,7 +577,7 @@ final class CalendarImplemTests: XCTestCase {
                     title: "title",
                     color: UIColor.red,
                     isWritable: true,
-                    sourceName: "local",
+                    account: Account(name: "local", type: "local"),
                     events: [
                         MockEvent(
                             id: "2",
@@ -627,7 +627,7 @@ final class CalendarImplemTests: XCTestCase {
                     title: "title",
                     color: UIColor.red,
                     isWritable: false,
-                    sourceName: "local",
+                    account: Account(name: "local", type: "local"),
                     events: [
                         MockEvent(
                             id: "2",
@@ -679,7 +679,7 @@ final class CalendarImplemTests: XCTestCase {
                     title: "title",
                     color: UIColor.red,
                     isWritable: true,
-                    sourceName: "local",
+                    account: Account(name: "local", type: "local"),
                     events: [
                         MockEvent(
                             id: "1",
@@ -728,7 +728,7 @@ final class CalendarImplemTests: XCTestCase {
                     title: "title",
                     color: UIColor.red,
                     isWritable: true,
-                    sourceName: "local",
+                    account: Account(name: "local", type: "local"),
                     events: [
                         MockEvent(
                             id: "2",
@@ -778,7 +778,7 @@ final class CalendarImplemTests: XCTestCase {
                     title: "title",
                     color: UIColor.red,
                     isWritable: true,
-                    sourceName: "local",
+                    account: Account(name: "local", type: "local"),
                     events: [
                         MockEvent(
                             id: "1",
@@ -825,7 +825,7 @@ final class CalendarImplemTests: XCTestCase {
                     title: "title",
                     color: UIColor.red,
                     isWritable: true,
-                    sourceName: "local",
+                    account: Account(name: "local", type: "local"),
                     events: [
                         MockEvent(
                             id: "2",
@@ -876,7 +876,7 @@ final class CalendarImplemTests: XCTestCase {
                     title: "title",
                     color: UIColor.red,
                     isWritable: true,
-                    sourceName: "local",
+                    account: Account(name: "local", type: "local"),
                     events: [
                         MockEvent(
                             id: "1",
@@ -927,7 +927,7 @@ final class CalendarImplemTests: XCTestCase {
             permissionHandler: PermissionRefused()
         )
         
-        calendarImplem.createCalendar(title: "title", color: 0xFF0000) { createCalendarResult in
+        calendarImplem.createCalendar(title: "title", color: 0xFF0000, account: nil) { createCalendarResult in
             switch (createCalendarResult) {
             case .success:
                 XCTFail("Calendar should not have been created")
@@ -983,7 +983,7 @@ final class CalendarImplemTests: XCTestCase {
                     title: "title",
                     color: UIColor.red,
                     isWritable: true,
-                    sourceName: "local",
+                    account: Account(name: "local", type: "local"),
                     events: []
                 )
             ]
@@ -1022,7 +1022,7 @@ final class CalendarImplemTests: XCTestCase {
                     title: "title",
                     color: UIColor.red,
                     isWritable: true,
-                    sourceName: "local",
+                    account: Account(name: "local", type: "local"),
                     events: []
                 )
             ]
@@ -1069,7 +1069,7 @@ final class CalendarImplemTests: XCTestCase {
                     title: "title",
                     color: UIColor.red,
                     isWritable: true,
-                    sourceName: "local",
+                    account: Account(name: "local", type: "local"),
                     events: []
                 )
             ]
@@ -1112,7 +1112,7 @@ final class CalendarImplemTests: XCTestCase {
                     title: "title",
                     color: UIColor.red,
                     isWritable: true,
-                    sourceName: "local",
+                    account: Account(name: "local", type: "local"),
                     events: [
                         MockEvent(
                             id: "1",
@@ -1164,7 +1164,7 @@ final class CalendarImplemTests: XCTestCase {
                     title: "title",
                     color: UIColor.red,
                     isWritable: true,
-                    sourceName: "local",
+                    account: Account(name: "local", type: "local"),
                     events: [
                         MockEvent(
                             id: "1",
@@ -1214,7 +1214,7 @@ final class CalendarImplemTests: XCTestCase {
                     title: "title",
                     color: UIColor.red,
                     isWritable: true,
-                    sourceName: "local",
+                    account: Account(name: "local", type: "local"),
                     events: [
                         MockEvent(
                             id: "1",

--- a/example/ios/EventideTests/CalendarImplemTests.swift
+++ b/example/ios/EventideTests/CalendarImplemTests.swift
@@ -149,6 +149,95 @@ final class CalendarImplemTests: XCTestCase {
         waitForExpectations(timeout: timeout)
     }
     
+    func testRetrieveCalendars_onlyWritableWithAccountFilter_permissionGranted() {
+        let expectation = expectation(description: "No eligible calendar")
+        
+        let account1 = Account(name: "local", type: "local")
+        let account2 = Account(name: "iCloud", type: "calDAV")
+        let mockEasyEventStore = MockEasyEventStore(
+            calendars: [
+                MockCalendar(
+                    id: "1",
+                    title: "title",
+                    color: UIColor.red,
+                    isWritable: false,
+                    account: account1,
+                    events: []
+                ),
+                MockCalendar(
+                    id: "2",
+                    title: "title",
+                    color: UIColor.blue,
+                    isWritable: true,
+                    account: account2,
+                    events: []
+                )
+            ]
+        )
+        
+        calendarImplem = CalendarImplem(
+            easyEventStore: mockEasyEventStore,
+            permissionHandler: PermissionGranted()
+        )
+        
+        calendarImplem.retrieveCalendars(onlyWritableCalendars: true, from: account1) { retrieveCalendarsResult in
+            switch (retrieveCalendarsResult) {
+            case .success(let calendars):
+                XCTAssert(calendars.isEmpty)
+                expectation.fulfill()
+            case .failure:
+                XCTFail("Calendars should have been retrieved")
+            }
+        }
+        
+        waitForExpectations(timeout: timeout)
+    }
+    
+    func testRetrieveCalendars_accountFilter_permissionGranted() {
+        let expectation = expectation(description: "Calendar has been retrieved")
+        
+        let account1 = Account(name: "local", type: "local")
+        let account2 = Account(name: "iCloud", type: "calDAV")
+        let mockEasyEventStore = MockEasyEventStore(
+            calendars: [
+                MockCalendar(
+                    id: "1",
+                    title: "title",
+                    color: UIColor.red,
+                    isWritable: false,
+                    account: account1,
+                    events: []
+                ),
+                MockCalendar(
+                    id: "2",
+                    title: "title",
+                    color: UIColor.blue,
+                    isWritable: true,
+                    account: account2,
+                    events: []
+                )
+            ]
+        )
+        
+        calendarImplem = CalendarImplem(
+            easyEventStore: mockEasyEventStore,
+            permissionHandler: PermissionGranted()
+        )
+        
+        calendarImplem.retrieveCalendars(onlyWritableCalendars: false, from: account2) { retrieveCalendarsResult in
+            switch (retrieveCalendarsResult) {
+            case .success(let calendars):
+                XCTAssert(calendars.count == 1)
+                XCTAssert(calendars.last!.id == "2")
+                expectation.fulfill()
+            case .failure:
+                XCTFail("Calendars should have been retrieved")
+            }
+        }
+        
+        waitForExpectations(timeout: timeout)
+    }
+    
     func testRetrieveCalendars_all_permissionGranted() {
         let expectation = expectation(description: "Calendars have been retrieved")
         

--- a/example/ios/EventideTests/Mocks/MockEasyEventStore.swift
+++ b/example/ios/EventideTests/Mocks/MockEasyEventStore.swift
@@ -31,9 +31,16 @@ class MockEasyEventStore: EasyEventStoreProtocol {
         return calendar.toCalendar()
     }
     
-    func retrieveCalendars(onlyWritable: Bool) -> [eventide.Calendar] {
+    func retrieveCalendars(
+        onlyWritable: Bool,
+        from account: Account?
+    ) -> [eventide.Calendar] {
         return calendars
             .filter { onlyWritable && $0.isWritable || !onlyWritable }
+            .filter { calendar in
+                guard let account = account else { return true }
+                return calendar.account.name == account.name && calendar.account.type == account.type
+            }
             .map { $0.toCalendar() }
     }
     

--- a/example/ios/EventideTests/Mocks/MockEasyEventStore.swift
+++ b/example/ios/EventideTests/Mocks/MockEasyEventStore.swift
@@ -16,13 +16,13 @@ class MockEasyEventStore: EasyEventStoreProtocol {
         self.calendars = calendars
     }
     
-    func createCalendar(title: String, color: UIColor) throws -> eventide.Calendar {
+    func createCalendar(title: String, color: UIColor, account: Account?) throws -> eventide.Calendar {
         let calendar = MockCalendar(
             id: "id",
             title: title,
             color: color,
             isWritable: true,
-            sourceName: "iCloud",
+            account: account ?? Account(name: "iCloud", type: "calDAV"),
             events: []
         )
         
@@ -173,15 +173,15 @@ class MockCalendar {
     let title: String
     let color: UIColor
     let isWritable: Bool
-    let sourceName: String
+    let account: Account
     var events: [MockEvent]
     
-    init(id: String, title: String, color: UIColor, isWritable: Bool, sourceName: String, events: [MockEvent]) {
+    init(id: String, title: String, color: UIColor, isWritable: Bool, account: Account, events: [MockEvent]) {
         self.id = id
         self.title = title
         self.color = color
         self.isWritable = isWritable
-        self.sourceName = sourceName
+        self.account = account
         self.events = events
     }
     
@@ -191,7 +191,7 @@ class MockCalendar {
             title: title,
             color: color.toInt64(),
             isWritable: isWritable,
-            sourceName: sourceName
+            account: account
         )
     }
 }

--- a/ios/Classes/CalendarApi.g.swift
+++ b/ios/Classes/CalendarApi.g.swift
@@ -73,7 +73,7 @@ private func nilOrValue<T>(_ value: Any?) -> T? {
 /// [color] is the color of the calendar.
 ///
 /// [isWritable] is a boolean to indicate if the calendar is writable.
-/// 
+///
 /// [account] is the account the calendar belongs to
 /// TODO: explain android/ios differences
 ///
@@ -260,7 +260,7 @@ class CalendarApiPigeonCodec: FlutterStandardMessageCodec, @unchecked Sendable {
 protocol CalendarApi {
   func requestCalendarPermission(completion: @escaping (Result<Bool, Error>) -> Void)
   func createCalendar(title: String, color: Int64, account: Account?, completion: @escaping (Result<Calendar, Error>) -> Void)
-  func retrieveCalendars(onlyWritableCalendars: Bool, completion: @escaping (Result<[Calendar], Error>) -> Void)
+  func retrieveCalendars(onlyWritableCalendars: Bool, from: Account?, completion: @escaping (Result<[Calendar], Error>) -> Void)
   func deleteCalendar(_ calendarId: String, completion: @escaping (Result<Void, Error>) -> Void)
   func createEvent(calendarId: String, title: String, startDate: Int64, endDate: Int64, isAllDay: Bool, description: String?, url: String?, completion: @escaping (Result<Event, Error>) -> Void)
   func retrieveEvents(calendarId: String, startDate: Int64, endDate: Int64, completion: @escaping (Result<[Event], Error>) -> Void)
@@ -314,7 +314,8 @@ class CalendarApiSetup {
       retrieveCalendarsChannel.setMessageHandler { message, reply in
         let args = message as! [Any?]
         let onlyWritableCalendarsArg = args[0] as! Bool
-        api.retrieveCalendars(onlyWritableCalendars: onlyWritableCalendarsArg) { result in
+        let fromArg: Account? = nilOrValue(args[1])
+        api.retrieveCalendars(onlyWritableCalendars: onlyWritableCalendarsArg, from: fromArg) { result in
           switch result {
           case .success(let res):
             reply(wrapResult(res))

--- a/ios/Classes/CalendarApi.g.swift
+++ b/ios/Classes/CalendarApi.g.swift
@@ -65,16 +65,17 @@ private func nilOrValue<T>(_ value: Any?) -> T? {
 }
 
 /// Native data struct to represent a calendar.
-/// 
+///
 /// [id] is a unique identifier for the calendar.
-/// 
+///
 /// [title] is the title of the calendar.
-/// 
+///
 /// [color] is the color of the calendar.
-/// 
+///
 /// [isWritable] is a boolean to indicate if the calendar is writable.
 /// 
-/// [sourceName] is the name of the source of the calendar.
+/// [account] is the account the calendar belongs to
+/// TODO: explain android/ios differences
 ///
 /// Generated class from Pigeon that represents data sent in messages.
 struct Calendar {
@@ -82,7 +83,7 @@ struct Calendar {
   var title: String
   var color: Int64
   var isWritable: Bool
-  var sourceName: String
+  var account: Account
 
 
   // swift-format-ignore: AlwaysUseLowerCamelCase
@@ -91,14 +92,14 @@ struct Calendar {
     let title = pigeonVar_list[1] as! String
     let color = pigeonVar_list[2] as! Int64
     let isWritable = pigeonVar_list[3] as! Bool
-    let sourceName = pigeonVar_list[4] as! String
+    let account = pigeonVar_list[4] as! Account
 
     return Calendar(
       id: id,
       title: title,
       color: color,
       isWritable: isWritable,
-      sourceName: sourceName
+      account: account
     )
   }
   func toList() -> [Any?] {
@@ -107,29 +108,29 @@ struct Calendar {
       title,
       color,
       isWritable,
-      sourceName,
+      account,
     ]
   }
 }
 
 /// Native data struct to represent an event.
-/// 
+///
 /// [id] is a unique identifier for the event.
-/// 
+///
 /// [title] is the title of the event.
-/// 
+///
 /// [isAllDay] is whether or not the event is an all day.
-/// 
+///
 /// [startDate] is the start date of the event in milliseconds since epoch.
-/// 
+///
 /// [endDate] is the end date of the event in milliseconds since epoch.
-/// 
+///
 /// [calendarId] is the id of the calendar that the event belongs to.
-/// 
+///
 /// [description] is the description of the event.
-/// 
-/// [url] is the url of the event.  
-/// 
+///
+/// [url] is the url of the event.
+///
 /// [reminders] is a list of minutes before the event to remind the user.
 ///
 /// Generated class from Pigeon that represents data sent in messages.
@@ -184,6 +185,30 @@ struct Event {
   }
 }
 
+/// Generated class from Pigeon that represents data sent in messages.
+struct Account {
+  var name: String
+  var type: String
+
+
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ pigeonVar_list: [Any?]) -> Account? {
+    let name = pigeonVar_list[0] as! String
+    let type = pigeonVar_list[1] as! String
+
+    return Account(
+      name: name,
+      type: type
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      name,
+      type,
+    ]
+  }
+}
+
 private class CalendarApiPigeonCodecReader: FlutterStandardReader {
   override func readValue(ofType type: UInt8) -> Any? {
     switch type {
@@ -191,6 +216,8 @@ private class CalendarApiPigeonCodecReader: FlutterStandardReader {
       return Calendar.fromList(self.readValue() as! [Any?])
     case 130:
       return Event.fromList(self.readValue() as! [Any?])
+    case 131:
+      return Account.fromList(self.readValue() as! [Any?])
     default:
       return super.readValue(ofType: type)
     }
@@ -204,6 +231,9 @@ private class CalendarApiPigeonCodecWriter: FlutterStandardWriter {
       super.writeValue(value.toList())
     } else if let value = value as? Event {
       super.writeByte(130)
+      super.writeValue(value.toList())
+    } else if let value = value as? Account {
+      super.writeByte(131)
       super.writeValue(value.toList())
     } else {
       super.writeValue(value)
@@ -229,7 +259,7 @@ class CalendarApiPigeonCodec: FlutterStandardMessageCodec, @unchecked Sendable {
 /// Generated protocol from Pigeon that represents a handler of messages from Flutter.
 protocol CalendarApi {
   func requestCalendarPermission(completion: @escaping (Result<Bool, Error>) -> Void)
-  func createCalendar(title: String, color: Int64, completion: @escaping (Result<Calendar, Error>) -> Void)
+  func createCalendar(title: String, color: Int64, account: Account?, completion: @escaping (Result<Calendar, Error>) -> Void)
   func retrieveCalendars(onlyWritableCalendars: Bool, completion: @escaping (Result<[Calendar], Error>) -> Void)
   func deleteCalendar(_ calendarId: String, completion: @escaping (Result<Void, Error>) -> Void)
   func createEvent(calendarId: String, title: String, startDate: Int64, endDate: Int64, isAllDay: Bool, description: String?, url: String?, completion: @escaping (Result<Event, Error>) -> Void)
@@ -266,7 +296,8 @@ class CalendarApiSetup {
         let args = message as! [Any?]
         let titleArg = args[0] as! String
         let colorArg = args[1] as! Int64
-        api.createCalendar(title: titleArg, color: colorArg) { result in
+        let accountArg: Account? = nilOrValue(args[2])
+        api.createCalendar(title: titleArg, color: colorArg, account: accountArg) { result in
           switch result {
           case .success(let res):
             reply(wrapResult(res))

--- a/ios/Classes/CalendarImplem.swift
+++ b/ios/Classes/CalendarImplem.swift
@@ -8,8 +8,8 @@
 import Foundation
 
 class CalendarImplem: CalendarApi {
-    let easyEventStore: EasyEventStoreProtocol
-    let permissionHandler: PermissionHandlerProtocol
+    private let easyEventStore: EasyEventStoreProtocol
+    private let permissionHandler: PermissionHandlerProtocol
     
     init(easyEventStore: EasyEventStoreProtocol, permissionHandler: PermissionHandlerProtocol) {
         self.easyEventStore = easyEventStore
@@ -24,12 +24,12 @@ class CalendarImplem: CalendarApi {
         } onPermissionError: { error in
             completion(.failure(error))
         }
-
     }
     
     func createCalendar(
         title: String,
         color: Int64,
+        account: Account?,
         completion: @escaping (Result<Calendar, Error>) -> Void
     ) {
         permissionHandler.checkCalendarAccessThenExecute { [self] in
@@ -43,7 +43,7 @@ class CalendarImplem: CalendarApi {
             }
             
             do {
-                let createdCalendar = try easyEventStore.createCalendar(title: title, color: uiColor)
+                let createdCalendar = try easyEventStore.createCalendar(title: title, color: uiColor, account: account)
                 completion(.success(createdCalendar))
                 
             } catch {

--- a/ios/Classes/CalendarImplem.swift
+++ b/ios/Classes/CalendarImplem.swift
@@ -62,9 +62,13 @@ class CalendarImplem: CalendarApi {
 
     }
 
-    func retrieveCalendars(onlyWritableCalendars: Bool, completion: @escaping (Result<[Calendar], Error>) -> Void) {
+    func retrieveCalendars(
+        onlyWritableCalendars: Bool,
+        from account: Account? = nil,
+        completion: @escaping (Result<[Calendar], Error>) -> Void
+    ) {
         permissionHandler.checkCalendarAccessThenExecute { [self] in
-            let calendars = easyEventStore.retrieveCalendars(onlyWritable: onlyWritableCalendars)
+            let calendars = easyEventStore.retrieveCalendars(onlyWritable: onlyWritableCalendars, from: account)
             completion(.success(calendars))
             
         } onPermissionRefused: {

--- a/ios/Classes/EasyEventStore/EasyEventStore.swift
+++ b/ios/Classes/EasyEventStore/EasyEventStore.swift
@@ -43,9 +43,16 @@ final class EasyEventStore: EasyEventStoreProtocol {
         }
     }
     
-    func retrieveCalendars(onlyWritable: Bool) -> [Calendar] {
+    func retrieveCalendars(
+        onlyWritable: Bool,
+        from account: Account?
+    ) -> [Calendar] {
         return eventStore.calendars(for: .event)
             .filter { onlyWritable ? $0.allowsContentModifications : true }
+            .filter { calendar in
+                guard let account = account else { return true }
+                return account.name == calendar.source.sourceIdentifier && account.type == calendar.source.sourceType.toString()
+            }
             .map { $0.toCalendar() }
     }
     

--- a/ios/Classes/EasyEventStore/EasyEventStore.swift
+++ b/ios/Classes/EasyEventStore/EasyEventStore.swift
@@ -14,8 +14,8 @@ final class EasyEventStore: EasyEventStoreProtocol {
         self.eventStore = eventStore
     }
     
-    func createCalendar(title: String, color: UIColor) throws -> Calendar {
-        guard let source = getSource() else {
+    func createCalendar(title: String, color: UIColor, account: Account?) throws -> Calendar {
+        guard let source = getSource(account: account) else {
             throw PigeonError(
                 code: "NOT_FOUND",
                 message: "Calendar source was not found",
@@ -31,7 +31,7 @@ final class EasyEventStore: EasyEventStoreProtocol {
         
         do {
             try eventStore.saveCalendar(ekCalendar, commit: true)
-            return ekCalendar.toEasyCalendar()
+            return ekCalendar.toCalendar()
             
         } catch {
             eventStore.reset()
@@ -46,7 +46,7 @@ final class EasyEventStore: EasyEventStoreProtocol {
     func retrieveCalendars(onlyWritable: Bool) -> [Calendar] {
         return eventStore.calendars(for: .event)
             .filter { onlyWritable ? $0.allowsContentModifications : true }
-            .map { $0.toEasyCalendar() }
+            .map { $0.toCalendar() }
     }
     
     func deleteCalendar(calendarId: String) throws {
@@ -104,7 +104,7 @@ final class EasyEventStore: EasyEventStoreProtocol {
         
         do {
             try eventStore.save(ekEvent, span: EKSpan.thisEvent, commit: true)
-            return ekEvent.toEasyEvent()
+            return ekEvent.toEvent()
             
         } catch {
             eventStore.reset()
@@ -131,7 +131,7 @@ final class EasyEventStore: EasyEventStoreProtocol {
             calendars: [calendar]
         )
         
-        return eventStore.events(matching: predicate).map { $0.toEasyEvent() }
+        return eventStore.events(matching: predicate).map { $0.toEvent() }
     }
     
     func deleteEvent(eventId: String) throws {
@@ -182,7 +182,7 @@ final class EasyEventStore: EasyEventStoreProtocol {
 
         do {
             try eventStore.save(ekEvent, span: EKSpan.thisEvent, commit: true)
-            return ekEvent.toEasyEvent()
+            return ekEvent.toEvent()
             
         } catch {
             eventStore.reset()
@@ -217,7 +217,7 @@ final class EasyEventStore: EasyEventStoreProtocol {
         
         do {
             try self.eventStore.save(ekEvent, span: EKSpan.thisEvent, commit: true)
-            return ekEvent.toEasyEvent()
+            return ekEvent.toEvent()
             
         } catch {
             self.eventStore.reset()
@@ -229,10 +229,17 @@ final class EasyEventStore: EasyEventStoreProtocol {
         }
     }
     
-    private func getSource() -> EKSource? {
+    private func getSource(account: Account?) -> EKSource? {
         guard let defaultSource = eventStore.defaultCalendarForNewEvents?.source else {
             // if eventStore.defaultCalendarForNewEvents?.source is nil then eventStore.sources is empty
             return nil
+        }
+        
+        if let account = account, let sourceType = EKSourceType(from: account.type) {
+            let wantedSources = eventStore.sources.filter { $0.sourceType == sourceType && $0.sourceIdentifier == account.name }
+            if !wantedSources.isEmpty {
+                return wantedSources.first
+            }
         }
         
         let iCloudSources = eventStore.sources.filter { $0.sourceType == .calDAV && $0.sourceIdentifier == "iCloud" }
@@ -252,19 +259,22 @@ final class EasyEventStore: EasyEventStoreProtocol {
 }
 
 fileprivate extension EKCalendar {
-    func toEasyCalendar() -> Calendar {
+    func toCalendar() -> Calendar {
         Calendar(
             id: calendarIdentifier,
             title: title,
             color: UIColor(cgColor: cgColor).toInt64(),
             isWritable: allowsContentModifications,
-            sourceName: source.sourceIdentifier
+            account: Account(
+                name: source.sourceIdentifier,
+                type: source.sourceType.toString()
+            )
         )
     }
 }
 
 fileprivate extension EKEvent {
-    func toEasyEvent() -> Event {
+    func toEvent() -> Event {
         Event(
             id: eventIdentifier,
             title: title,
@@ -276,5 +286,54 @@ fileprivate extension EKEvent {
             url: url?.absoluteString,
             reminders: alarms?.map { Int64($0.relativeOffset) }
         )
+    }
+}
+
+fileprivate extension EKSource {
+    func toAccount() -> Account {
+        return Account(
+            name: sourceIdentifier,
+            type: sourceType.toString()
+        )
+    }
+}
+
+fileprivate extension EKSourceType {
+     init?(from string: String) {
+        switch string.lowercased() {
+        case "local":
+            self = .local
+        case "caldav":
+            self = .calDAV
+        case "exchange":
+            self = .exchange
+        case "subscribed":
+            self = .subscribed
+        case "mobileme":
+            self = .mobileMe
+        case "birthdays":
+            self = .birthdays
+        default:
+            return nil
+        }
+    }
+
+    func toString() -> String {
+        switch self {
+        case .local:
+            return "Local"
+        case .calDAV:
+            return "CalDAV"
+        case .exchange:
+            return "Exchange"
+        case .subscribed:
+            return "Subscribed"
+        case .mobileMe:
+            return "MobileMe"
+        case .birthdays:
+            return "Birthdays"
+        @unknown default:
+            return "Local"
+        }
     }
 }

--- a/ios/Classes/EasyEventStore/EasyEventStoreProtocol.swift
+++ b/ios/Classes/EasyEventStore/EasyEventStoreProtocol.swift
@@ -10,7 +10,7 @@ import Foundation
 protocol EasyEventStoreProtocol {
     func createCalendar(title: String, color: UIColor, account: Account?) throws -> Calendar
     
-    func retrieveCalendars(onlyWritable: Bool) -> [Calendar]
+    func retrieveCalendars(onlyWritable: Bool, from account: Account?) -> [Calendar]
     
     func deleteCalendar(calendarId: String) throws -> Void
     

--- a/ios/Classes/EasyEventStore/EasyEventStoreProtocol.swift
+++ b/ios/Classes/EasyEventStore/EasyEventStoreProtocol.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 protocol EasyEventStoreProtocol {
-    func createCalendar(title: String, color: UIColor) throws -> Calendar
+    func createCalendar(title: String, color: UIColor, account: Account?) throws -> Calendar
     
     func retrieveCalendars(onlyWritable: Bool) -> [Calendar]
     

--- a/lib/eventide.dart
+++ b/lib/eventide.dart
@@ -1,7 +1,7 @@
 library eventide;
 
 export 'src/eventide.dart' show Eventide;
-export 'src/eventide_platform_interface.dart' show ETCalendar, ETEvent;
+export 'src/eventide_platform_interface.dart' show ETCalendar, ETEvent, ETAccount;
 export 'src/eventide_exception.dart'
     show
         ETException,

--- a/lib/src/calendar_api.g.dart
+++ b/lib/src/calendar_api.g.dart
@@ -288,7 +288,7 @@ class CalendarApi {
   }
 
   Future<List<Calendar>> retrieveCalendars(
-      {required bool onlyWritableCalendars}) async {
+      {required bool onlyWritableCalendars, required Account? from}) async {
     final String pigeonVar_channelName =
         'dev.flutter.pigeon.eventide.CalendarApi.retrieveCalendars$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
@@ -298,7 +298,7 @@ class CalendarApi {
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final List<Object?>? pigeonVar_replyList = await pigeonVar_channel
-        .send(<Object?>[onlyWritableCalendars]) as List<Object?>?;
+        .send(<Object?>[onlyWritableCalendars, from]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {

--- a/lib/src/calendar_api.g.dart
+++ b/lib/src/calendar_api.g.dart
@@ -25,14 +25,15 @@ PlatformException _createConnectionError(String channelName) {
 ///
 /// [isWritable] is a boolean to indicate if the calendar is writable.
 ///
-/// [sourceName] is the name of the source of the calendar.
+/// [account] is the account the calendar belongs to
+/// TODO: explain android/ios differences
 class Calendar {
   Calendar({
     required this.id,
     required this.title,
     required this.color,
     required this.isWritable,
-    required this.sourceName,
+    required this.account,
   });
 
   String id;
@@ -43,7 +44,7 @@ class Calendar {
 
   bool isWritable;
 
-  String sourceName;
+  Account account;
 
   Object encode() {
     return <Object?>[
@@ -51,7 +52,7 @@ class Calendar {
       title,
       color,
       isWritable,
-      sourceName,
+      account,
     ];
   }
 
@@ -62,7 +63,7 @@ class Calendar {
       title: result[1]! as String,
       color: result[2]! as int,
       isWritable: result[3]! as bool,
-      sourceName: result[4]! as String,
+      account: result[4]! as Account,
     );
   }
 }
@@ -147,6 +148,32 @@ class Event {
   }
 }
 
+class Account {
+  Account({
+    required this.name,
+    required this.type,
+  });
+
+  String name;
+
+  String type;
+
+  Object encode() {
+    return <Object?>[
+      name,
+      type,
+    ];
+  }
+
+  static Account decode(Object result) {
+    result as List<Object?>;
+    return Account(
+      name: result[0]! as String,
+      type: result[1]! as String,
+    );
+  }
+}
+
 class _PigeonCodec extends StandardMessageCodec {
   const _PigeonCodec();
   @override
@@ -160,6 +187,9 @@ class _PigeonCodec extends StandardMessageCodec {
     } else if (value is Event) {
       buffer.putUint8(130);
       writeValue(buffer, value.encode());
+    } else if (value is Account) {
+      buffer.putUint8(131);
+      writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
     }
@@ -172,6 +202,8 @@ class _PigeonCodec extends StandardMessageCodec {
         return Calendar.decode(readValue(buffer)!);
       case 130:
         return Event.decode(readValue(buffer)!);
+      case 131:
+        return Account.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);
     }
@@ -222,8 +254,11 @@ class CalendarApi {
     }
   }
 
-  Future<Calendar> createCalendar(
-      {required String title, required int color}) async {
+  Future<Calendar> createCalendar({
+    required String title,
+    required int color,
+    required Account? account,
+  }) async {
     final String pigeonVar_channelName =
         'dev.flutter.pigeon.eventide.CalendarApi.createCalendar$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
@@ -232,8 +267,8 @@ class CalendarApi {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final List<Object?>? pigeonVar_replyList =
-        await pigeonVar_channel.send(<Object?>[title, color]) as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList = await pigeonVar_channel
+        .send(<Object?>[title, color, account]) as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {

--- a/lib/src/eventide.dart
+++ b/lib/src/eventide.dart
@@ -27,7 +27,9 @@ class Eventide extends EventidePlatform {
     }
   }
 
-  /// Creates a new calendar with the given [title] and [color].
+  /// Creates a new calendar with the given [title], [color] and [accountName].
+  ///
+  /// Note that [accountName] is an Android feature. It will be ignored on iOS.
   ///
   /// Returns the created [ETCalendar].
   ///
@@ -40,11 +42,17 @@ class Eventide extends EventidePlatform {
   /// Throws a [ETGenericException] if any other error occurs during calendar creation.
 
   @override
-  Future<ETCalendar> createCalendar(
-      {required String title, required Color color}) async {
+  Future<ETCalendar> createCalendar({
+    required String title,
+    required Color color,
+    ETAccount? account,
+  }) async {
     try {
       final calendar = await _calendarApi.createCalendar(
-          title: title, color: color.toValue());
+        title: title,
+        color: color.toValue(),
+        account: account?.toAccount(),
+      );
       return calendar.toETCalendar();
     } on PlatformException catch (e) {
       throw e.toETException();
@@ -60,8 +68,9 @@ class Eventide extends EventidePlatform {
   ///
   /// Throws a [ETGenericException] if any other error occurs during calendars retrieval.
   @override
-  Future<List<ETCalendar>> retrieveCalendars(
-      {bool onlyWritableCalendars = true}) async {
+  Future<List<ETCalendar>> retrieveCalendars({
+    bool onlyWritableCalendars = true,
+  }) async {
     try {
       final calendars = await _calendarApi.retrieveCalendars(
           onlyWritableCalendars: onlyWritableCalendars);
@@ -81,7 +90,9 @@ class Eventide extends EventidePlatform {
   ///
   /// Throws a [ETGenericException] if any other error occurs during calendar deletion.
   @override
-  Future<void> deleteCalendar({required String calendarId}) async {
+  Future<void> deleteCalendar({
+    required String calendarId,
+  }) async {
     try {
       await _calendarApi.deleteCalendar(calendarId: calendarId);
     } on PlatformException catch (e) {
@@ -139,10 +150,11 @@ class Eventide extends EventidePlatform {
   ///
   /// Throws a [ETGenericException] if any other error occurs during events retrieval.
   @override
-  Future<List<ETEvent>> retrieveEvents(
-      {required String calendarId,
-      DateTime? startDate,
-      DateTime? endDate}) async {
+  Future<List<ETEvent>> retrieveEvents({
+    required String calendarId,
+    DateTime? startDate,
+    DateTime? endDate,
+  }) async {
     try {
       final start = startDate ?? DateTime.now();
       final end = endDate ?? DateTime.now().add(const Duration(days: 7));
@@ -167,7 +179,9 @@ class Eventide extends EventidePlatform {
   ///
   /// Throws a [ETGenericException] if any other error occurs during event deletion.
   @override
-  Future<void> deleteEvent({required String eventId}) async {
+  Future<void> deleteEvent({
+    required String eventId,
+  }) async {
     try {
       await _calendarApi.deleteEvent(eventId: eventId);
     } on PlatformException catch (e) {

--- a/lib/src/eventide.dart
+++ b/lib/src/eventide.dart
@@ -70,10 +70,13 @@ class Eventide extends EventidePlatform {
   @override
   Future<List<ETCalendar>> retrieveCalendars({
     bool onlyWritableCalendars = true,
+    ETAccount? fromAccount,
   }) async {
     try {
       final calendars = await _calendarApi.retrieveCalendars(
-          onlyWritableCalendars: onlyWritableCalendars);
+        onlyWritableCalendars: onlyWritableCalendars,
+        from: fromAccount?.toAccount(),
+      );
       return calendars.toETCalendarList();
     } on PlatformException catch (e) {
       throw e.toETException();

--- a/lib/src/eventide_extensions.dart
+++ b/lib/src/eventide_extensions.dart
@@ -14,19 +14,19 @@ extension ColorToValue on Color {
   int _floatToInt8(double x) => (x * 255.0).round() & 0xff;
 }
 
-extension CalendarToECCalendar on Calendar {
+extension CalendarToETCalendar on Calendar {
   ETCalendar toETCalendar() {
     return ETCalendar(
       id: id,
       title: title,
       color: Color(color),
       isWritable: isWritable,
-      sourceName: sourceName,
+      account: account.toETAccount(),
     );
   }
 }
 
-extension EventToECEvent on Event {
+extension EventToETEvent on Event {
   ETEvent toETEvent() {
     return ETEvent(
       id: id,
@@ -44,13 +44,31 @@ extension EventToECEvent on Event {
   }
 }
 
-extension CalendarListToECCalendar on List<Calendar> {
+extension AccountToETAccount on Account {
+  ETAccount toETAccount() {
+    return ETAccount(
+      name: name,
+      type: name,
+    );
+  }
+}
+
+extension ETAccountToAccount on ETAccount {
+  Account toAccount() {
+    return Account(
+      name: name,
+      type: name,
+    );
+  }
+}
+
+extension CalendarListToETCalendar on List<Calendar> {
   List<ETCalendar> toETCalendarList() {
     return map((c) => c.toETCalendar()).toList();
   }
 }
 
-extension EventListToECEvent on List<Event> {
+extension EventListToETEvent on List<Event> {
   List<ETEvent> toETEventList() {
     return map((e) => e.toETEvent()).toList();
   }

--- a/lib/src/eventide_platform_interface.dart
+++ b/lib/src/eventide_platform_interface.dart
@@ -2,6 +2,7 @@ import 'dart:ui';
 
 import 'package:eventide/src/eventide.dart';
 import 'package:equatable/equatable.dart';
+import 'package:flutter/services.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 abstract class EventidePlatform extends PlatformInterface {
@@ -23,6 +24,7 @@ abstract class EventidePlatform extends PlatformInterface {
   Future<ETCalendar> createCalendar({
     required String title,
     required Color color,
+    ETAccount? account,
   });
 
   Future<List<ETCalendar>> retrieveCalendars({
@@ -79,17 +81,17 @@ final class ETCalendar extends Equatable {
   final String title;
   final Color color;
   final bool isWritable;
-  final String sourceName;
+  final ETAccount account;
 
   @override
-  List<Object?> get props => [id, title, color, isWritable, sourceName];
+  List<Object?> get props => [id, title, color, isWritable, account];
 
   const ETCalendar({
     required this.id,
     required this.title,
     required this.color,
     required this.isWritable,
-    required this.sourceName,
+    required this.account,
   });
 }
 
@@ -144,5 +146,27 @@ final class ETEvent extends Equatable {
     this.description,
     this.url,
     this.reminders,
+  });
+}
+
+/// Represents an account.
+///
+/// [name] is the name of the account. It corresponds to CalendarContract.Calendars.ACCOUNT_NAME on Android and EKSource.sourceIdentifier on iOS.
+///
+/// [type] is the type of the account. It corresponds to CalendarContract.Calendars.ACCOUNT_TYPE on Android and EKSource.sourceType on iOS.
+///
+/// This class is used to represent the account that the calendar belongs to.
+///
+/// For example, if the calendar belongs to a Google account, the account name will be the email address of the Google account.
+final class ETAccount extends Equatable {
+  final String name;
+  final String type;
+
+  @override
+  List<Object?> get props => [name, type];
+
+  const ETAccount({
+    required this.name,
+    required this.type,
   });
 }

--- a/lib/src/eventide_platform_interface.dart
+++ b/lib/src/eventide_platform_interface.dart
@@ -29,6 +29,7 @@ abstract class EventidePlatform extends PlatformInterface {
 
   Future<List<ETCalendar>> retrieveCalendars({
     bool onlyWritableCalendars = true,
+    ETAccount? fromAccount,
   });
 
   Future<void> deleteCalendar({

--- a/pigeons/calendar_api.dart
+++ b/pigeons/calendar_api.dart
@@ -20,6 +20,7 @@ abstract class CalendarApi {
   Calendar createCalendar({
     required String title,
     required int color,
+    required Account? account,
   });
 
   @async
@@ -82,20 +83,21 @@ abstract class CalendarApi {
 ///
 /// [isWritable] is a boolean to indicate if the calendar is writable.
 ///
-/// [sourceName] is the name of the source of the calendar.
+/// [account] is the account the calendar belongs to
+/// TODO: explain android/ios differences
 final class Calendar {
   final String id;
   final String title;
   final int color;
   final bool isWritable;
-  final String sourceName;
+  final Account account;
 
   const Calendar({
     required this.id,
     required this.title,
     required this.color,
     required this.isWritable,
-    required this.sourceName,
+    required this.account,
   });
 }
 
@@ -139,5 +141,15 @@ final class Event {
     required this.description,
     required this.url,
     required this.reminders,
+  });
+}
+
+final class Account {
+  final String name;
+  final String type;
+
+  const Account({
+    required this.name,
+    required this.type,
   });
 }

--- a/pigeons/calendar_api.dart
+++ b/pigeons/calendar_api.dart
@@ -26,6 +26,7 @@ abstract class CalendarApi {
   @async
   List<Calendar> retrieveCalendars({
     required bool onlyWritableCalendars,
+    required Account? from,
   });
 
   @async

--- a/test/eventide_test.dart
+++ b/test/eventide_test.dart
@@ -77,41 +77,44 @@ void main() {
 
     test('retrieveCalendars returns a list of ETCalendars', () async {
       // Given
+      final account1 = Account(name: 'Test Account 1', type: 'Test Type 1');
+      final account2 = Account(name: 'Test Account 2', type: 'Test Type 2');
       final calendars = [
         Calendar(
           id: '1',
           title: 'Test Calendar 1',
           color: Colors.blue.toValue(),
           isWritable: true,
-          account: Account(name: 'Test Account 1', type: 'Test Type 1'),
+          account: account1,
         ),
         Calendar(
           id: '2',
           title: 'Test Calendar 2',
           color: Colors.red.toValue(),
           isWritable: true,
-          account: Account(name: 'Test Account 2', type: 'Test Type 2'),
+          account: account2,
         ),
       ];
       when(() => mockCalendarApi.retrieveCalendars(
-              onlyWritableCalendars: any(named: 'onlyWritableCalendars')))
-          .thenAnswer((_) async => calendars);
+        onlyWritableCalendars: any(named: 'onlyWritableCalendars'),
+        from: any(named: 'from'),
+      )).thenAnswer((_) async => [calendars.last]);
 
       // When
-      final result =
-          await eventide.retrieveCalendars(onlyWritableCalendars: true);
+      final result = await eventide.retrieveCalendars(onlyWritableCalendars: true);
 
       // Then
-      expect(result, equals(calendars.map((c) => c.toETCalendar()).toList()));
-      verify(() =>
-              mockCalendarApi.retrieveCalendars(onlyWritableCalendars: true))
-          .called(1);
+      expect(result, [calendars.last].toETCalendarList());
+      verify(() => mockCalendarApi.retrieveCalendars(
+        onlyWritableCalendars: true,
+        from: any(named: 'from'),
+      )).called(1);
     });
 
     test('retrieveCalendars throws an exception when API fails', () async {
       // Given
       when(() => mockCalendarApi.retrieveCalendars(
-              onlyWritableCalendars: any(named: 'onlyWritableCalendars')))
+              onlyWritableCalendars: any(named: 'onlyWritableCalendars'),from: null,))
           .thenThrow(Exception('API Error'));
 
       // When
@@ -121,7 +124,7 @@ void main() {
       // Then
       expect(call, throwsException);
       verify(() =>
-              mockCalendarApi.retrieveCalendars(onlyWritableCalendars: true))
+              mockCalendarApi.retrieveCalendars(onlyWritableCalendars: true,from: null,))
           .called(1);
     });
 

--- a/test/eventide_test.dart
+++ b/test/eventide_test.dart
@@ -25,33 +25,43 @@ void main() {
   group('Calendar tests', () {
     test('createCalendar returns an ETCalendar', () async {
       // Given
+      const etAccount = ETAccount(name: 'Test Account', type: 'Test Type');
       final calendar = Calendar(
         id: '1',
         title: 'Test Calendar',
         color: Colors.blue.toValue(),
         isWritable: true,
-        sourceName: 'local',
+        account: etAccount.toAccount(),
       );
 
       when(() => mockCalendarApi.createCalendar(
-          title: any(named: 'title'),
-          color: any(named: 'color'))).thenAnswer((_) async => calendar);
+            title: any(named: 'title'),
+            color: any(named: 'color'),
+            account: any(named: 'account'),
+          )).thenAnswer((_) async => calendar);
 
       // When
       final result = await eventide.createCalendar(
-          title: 'Test Calendar', color: Colors.blue);
+        title: 'Test Calendar',
+        color: Colors.blue,
+        account: etAccount,
+      );
 
       // Then
       expect(result, equals(calendar.toETCalendar()));
       verify(() => mockCalendarApi.createCalendar(
-          title: 'Test Calendar', color: Colors.blue.toValue())).called(1);
+            title: 'Test Calendar',
+            color: Colors.blue.toValue(),
+            account: any(named: 'account'),
+          )).called(1);
     });
 
     test('createCalendar throws an exception when API fails', () async {
       // Given
       when(() => mockCalendarApi.createCalendar(
           title: any(named: 'title'),
-          color: any(named: 'color'))).thenThrow(Exception('API Error'));
+          color: any(named: 'color'),
+          account: null)).thenThrow(Exception('API Error'));
 
       // When
       Future<ETCalendar> call() =>
@@ -60,24 +70,28 @@ void main() {
       // Then
       expect(call, throwsException);
       verify(() => mockCalendarApi.createCalendar(
-          title: 'Test Calendar', color: Colors.blue.toValue())).called(1);
+          title: 'Test Calendar',
+          color: Colors.blue.toValue(),
+          account: null)).called(1);
     });
 
     test('retrieveCalendars returns a list of ETCalendars', () async {
       // Given
       final calendars = [
         Calendar(
-            id: '1',
-            title: 'Test Calendar 1',
-            color: Colors.blue.toValue(),
-            isWritable: true,
-            sourceName: 'local'),
+          id: '1',
+          title: 'Test Calendar 1',
+          color: Colors.blue.toValue(),
+          isWritable: true,
+          account: Account(name: 'Test Account 1', type: 'Test Type 1'),
+        ),
         Calendar(
-            id: '2',
-            title: 'Test Calendar 2',
-            color: Colors.red.toValue(),
-            isWritable: true,
-            sourceName: 'local'),
+          id: '2',
+          title: 'Test Calendar 2',
+          color: Colors.red.toValue(),
+          isWritable: true,
+          account: Account(name: 'Test Account 2', type: 'Test Type 2'),
+        ),
       ];
       when(() => mockCalendarApi.retrieveCalendars(
               onlyWritableCalendars: any(named: 'onlyWritableCalendars')))


### PR DESCRIPTION
Expose a new type ETAccount { name, type }
- name = EKSource.sourceIdentifier and type = EKSource.sourceType on iOS
- name = CalendarContract.Calendars.ACCOUNT_NAME and type = CalendarContract.Calendars.ACCOUNT_TYPE on Android