### PR TITLE
Fix: Adjust Android test execution for Codecov

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -160,9 +160,9 @@ jobs:
         run: flutter pub get
 
       - name: Build and test
-        working-directory: ./android # Ajout du répertoire de travail
+        working-directory: ./android
         run: |
-          ./gradlew testDebugUnitTest
+          ./gradlew testDebugUnitTest --warning-mode all
 
       - name: Upload coverage report as artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -160,8 +160,9 @@ jobs:
         run: flutter pub get
 
       - name: Build and test
+        working-directory: ./android # Ajout du répertoire de travail
         run: |
-          ./example/android/gradlew testDebugUnitTest -p ./example/android/
+          ./gradlew testDebugUnitTest
 
       - name: Upload coverage report as artifact
         uses: actions/upload-artifact@v4

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,3 +1,9 @@
+plugins {
+    id 'com.android.library'
+    id 'kotlin-android'
+    id 'jacoco'
+}
+
 group 'sncf.connect.tech.eventide'
 version '1.0-SNAPSHOT'
 
@@ -19,12 +25,6 @@ allprojects {
         google()
         mavenCentral()
     }
-}
-
-plugins {
-    id 'com.android.library'
-    id 'kotlin-android'
-    id 'jacoco'
 }
 
 android {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,9 +21,11 @@ allprojects {
     }
 }
 
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
-apply plugin: 'jacoco'
+plugins {
+    id 'com.android.library'
+    id 'kotlin-android'
+    id 'jacoco'
+}
 
 android {
     compileSdk 35

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,3 @@
-group 'sncf.connect.tech.eventide'
-version '1.0-SNAPSHOT'
-
 buildscript {
     ext.kotlin_version = '1.7.10'
     repositories {
@@ -19,6 +16,9 @@ plugins {
     id 'kotlin-android'
     id 'jacoco'
 }
+
+group 'sncf.connect.tech.eventide'
+version '1.0-SNAPSHOT'
 
 allprojects {
     repositories {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,9 +1,3 @@
-plugins {
-    id 'com.android.library'
-    id 'kotlin-android'
-    id 'jacoco'
-}
-
 group 'sncf.connect.tech.eventide'
 version '1.0-SNAPSHOT'
 
@@ -18,6 +12,12 @@ buildscript {
         classpath "com.android.tools.build:gradle:8.8.2"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
+}
+
+plugins {
+    id 'com.android.library'
+    id 'kotlin-android'
+    id 'jacoco'
 }
 
 allprojects {

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/codecov.yml
+++ b/codecov.yml
@@ -18,7 +18,7 @@ coverage:
         target: 80%
         threshold: 5%
       android:
-        enabled: no # Disabled while android is not behaving with codecov
+        enabled: yes
         target: 80%
         threshold: 5%
     project:
@@ -31,7 +31,7 @@ coverage:
         target: 80%
         threshold: 5%
       android:
-        enabled: no # Disabled while android is not behaving with codecov
+        enabled: yes
         target: 80%
         threshold: 5%
 


### PR DESCRIPTION
- Modify GitHub Actions workflow to run Android tests within the 'android' module's directory. This ensures JaCoCo generates reports with paths relative to the 'android' module, which Codecov expects, especially with 'disable_default_path_fixes: true'.
- Re-enable Android coverage processing in 'codecov.yml'.