### PR TITLE
Updating syntax to properly communicate the returned event is not null on Android

### DIFF
--- a/android/src/main/kotlin/sncf/connect/tech/eventide/CalendarImplem.kt
+++ b/android/src/main/kotlin/sncf/connect/tech/eventide/CalendarImplem.kt
@@ -993,7 +993,7 @@ class CalendarImplem(
                     )
                 )
             } else {
-                callback(Result.success(event))
+                callback(Result.success(event!!))
             }
 
 


### PR DESCRIPTION
I'm achieving this by adding a force unwrapping to the returned event in the retrieveEvent method in CalendarImplem.kt