### PR TITLE
Replace 'LocalCalendar' by simple 'local' for default account name on…

### DIFF
--- a/android/src/main/kotlin/sncf/connect/tech/eventide/CalendarImplem.kt
+++ b/android/src/main/kotlin/sncf/connect/tech/eventide/CalendarImplem.kt
@@ -41,7 +41,7 @@ class CalendarImplem(
             CoroutineScope(Dispatchers.IO).launch {
                 try {
                     // Use provided accountName or default to device name
-                    val finalAccountName = account?.name ?: "LocalCalendar"
+                    val finalAccountName = account?.name ?: "local"
                     
                     val syncAdapterUri = calendarContentUri.buildUpon()
                         .appendQueryParameter(CalendarContract.CALLER_IS_SYNCADAPTER, "true")

--- a/lib/src/eventide.dart
+++ b/lib/src/eventide.dart
@@ -21,7 +21,7 @@ class Eventide extends EventidePlatform {
   /// If [account] is provided, the calendar will be created under that account.
   /// If [account] is null, the calendar will be created in the default account/source:
   /// - On iOS: Uses default source (local or iCloud)
-  /// - On Android: Uses "LocalCalendar" as the account name
+  /// - On Android: Uses "local" as the account name
   ///
   /// Returns the created [ETCalendar].
   ///


### PR DESCRIPTION
… android