### PR TITLE
Fix ICS format

### DIFF
--- a/android/src/main/kotlin/sncf/connect/tech/eventide/handler/IcsEventManager.kt
+++ b/android/src/main/kotlin/sncf/connect/tech/eventide/handler/IcsEventManager.kt
@@ -26,24 +26,24 @@ class IcsEventManager(private val context: Context) {
     ): String = StringBuilder().apply {
         val prodId = "-//${context.packageName}//EventidePlugin//FR"
 
-        appendLine("BEGIN:VCALENDAR")
-        appendLine("VERSION:2.0")
-        appendLine("PRODID:$prodId")
-        appendLine("CALSCALE:GREGORIAN")
-        appendLine("BEGIN:VEVENT")
+        crlf("BEGIN:VCALENDAR")
+        crlf("VERSION:2.0")
+        crlf("PRODID:$prodId")
+        crlf("CALSCALE:GREGORIAN")
+        crlf("BEGIN:VEVENT")
 
-        appendLine("UID:${UUID.randomUUID()}@${context.packageName}")
-        appendLine("DTSTAMP:${icsDateTimeFormat.format(Calendar.getInstance().getTime())}")
+        crlf("UID:${UUID.randomUUID()}@${context.packageName}")
+        crlf("DTSTAMP:${icsDateTimeFormat.format(Calendar.getInstance().getTime())}")
 
         val startDate = startDate ?: Calendar.getInstance().timeInMillis
         val endDate = endDate ?: (startDate + 60 * 60 * 1000)
 
         if (isAllDay ?: false) {
-            appendLine("DTSTART;VALUE=DATE:${icsDateFormat.format(Date(startDate))}")
-            appendLine("DTEND;VALUE=DATE:${icsDateFormat.format(Date(endDate))}")
+            crlf("DTSTART;VALUE=DATE:${icsDateFormat.format(Date(startDate))}")
+            crlf("DTEND;VALUE=DATE:${icsDateFormat.format(Date(endDate))}")
         } else {
-            appendLine("DTSTART:${icsDateTimeFormat.format(Date(startDate))}")
-            appendLine("DTEND:${icsDateTimeFormat.format(Date(endDate))}")
+            crlf("DTSTART:${icsDateTimeFormat.format(Date(startDate))}")
+            crlf("DTEND:${icsDateTimeFormat.format(Date(endDate))}")
         }
 
         title?.let { append(foldLine("SUMMARY:${escape(it)}")) }
@@ -51,15 +51,17 @@ class IcsEventManager(private val context: Context) {
         location?.let { append(foldLine("LOCATION:${escape(it)}")) }
 
         reminders?.forEach { minutes ->
-            appendLine("BEGIN:VALARM")
-            appendLine("TRIGGER:-PT${minutes}M")
-            appendLine("ACTION:DISPLAY")
-            appendLine("END:VALARM")
+            crlf("BEGIN:VALARM")
+            crlf("TRIGGER:-PT${minutes}M")
+            crlf("ACTION:DISPLAY")
+            crlf("END:VALARM")
         }
 
-        appendLine("END:VEVENT")
-        appendLine("END:VCALENDAR")
+        crlf("END:VEVENT")
+        crlf("END:VCALENDAR")
     }.toString()
+
+    private fun StringBuilder.crlf(line: String) = append(line).append("\r\n")
 
     /**
      * https://datatracker.ietf.org/doc/html/rfc5545#section-3.3.11
@@ -72,15 +74,62 @@ class IcsEventManager(private val context: Context) {
 
     /**
      * https://datatracker.ietf.org/doc/html/rfc5545#section-3.1
+     * Folds on 75-byte boundaries (not characters) as required by RFC 5545.
      */
     private fun foldLine(line: String): String {
         val sb = StringBuilder()
-        var currentLine = line
-        while (currentLine.length > 75) {
-            sb.append(currentLine.take(75)).append("\r\n ")
-            currentLine = currentLine.substring(75)
+        val bytes = line.toByteArray(Charsets.UTF_8)
+        var offset = 0
+        var firstChunk = true
+        
+        while (offset < bytes.size) {
+            val limit = if (firstChunk) 75 else 74 // continuation lines start with a space (1 byte)
+            val chunkBytes = bytes.copyOfRange(offset, minOf(offset + limit, bytes.size))
+            
+            // Trim to a valid UTF-8 boundary
+            var chunkLen = chunkBytes.size
+        
+            // Find the last non-continuation byte
+            var leadPos = chunkLen - 1
+        
+            while (leadPos >= 0 && (chunkBytes[leadPos].toInt() and 0xC0) == 0x80) {
+                leadPos--
+            }
+
+            // If that leading byte starts an incomplete multi-byte sequence, exclude it too
+            if (leadPos >= 0) {
+                val leadByte = chunkBytes[leadPos].toInt() and 0xFF
+                
+                val expectedContinuation = when {
+                    leadByte and 0xE0 == 0xC0 -> 1
+                    leadByte and 0xF0 == 0xE0 -> 2
+                    leadByte and 0xF8 == 0xF0 -> 3
+                    else -> 0
+                }
+
+                if (chunkLen - 1 - leadPos < expectedContinuation) {
+                    chunkLen = leadPos
+                }
+            }
+
+            val chunk = String(bytes.copyOfRange(offset, offset + chunkLen), Charsets.UTF_8)
+            
+            if (!firstChunk) {
+                sb.append(' ')
+            }
+
+            sb.append(chunk)
+            offset += chunkLen
+            
+            if (offset < bytes.size) {
+                sb.append("\r\n")
+            }
+
+            firstChunk = false
         }
-        sb.append(currentLine).append("\r\n")
+
+        sb.append("\r\n")
+        
         return sb.toString()
     }
 }

--- a/android/src/main/kotlin/sncf/connect/tech/eventide/handler/IcsEventManager.kt
+++ b/android/src/main/kotlin/sncf/connect/tech/eventide/handler/IcsEventManager.kt
@@ -26,11 +26,11 @@ class IcsEventManager(private val context: Context) {
     ): String = StringBuilder().apply {
         val prodId = "-//${context.packageName}//EventidePlugin//FR"
 
-        appendLine("BEGIN:VCALENDAR\n")
-        appendLine("VERSION:2.0\n")
-        appendLine("PRODID:$prodId\n")
+        appendLine("BEGIN:VCALENDAR")
+        appendLine("VERSION:2.0")
+        appendLine("PRODID:$prodId")
         appendLine("CALSCALE:GREGORIAN")
-        appendLine("BEGIN:VEVENT\n")
+        appendLine("BEGIN:VEVENT")
 
         appendLine("UID:${UUID.randomUUID()}@${context.packageName}")
         appendLine("DTSTAMP:${icsDateTimeFormat.format(Calendar.getInstance().getTime())}")
@@ -39,25 +39,25 @@ class IcsEventManager(private val context: Context) {
         val endDate = endDate ?: (startDate + 60 * 60 * 1000)
 
         if (isAllDay ?: false) {
-            appendLine("DTSTART;VALUE=DATE:${icsDateFormat.format(Date(startDate))}\n")
-            appendLine("DTEND;VALUE=DATE:${icsDateFormat.format(Date(endDate))}\n")
+            appendLine("DTSTART;VALUE=DATE:${icsDateFormat.format(Date(startDate))}")
+            appendLine("DTEND;VALUE=DATE:${icsDateFormat.format(Date(endDate))}")
         } else {
-            appendLine("DTSTART:${icsDateTimeFormat.format(Date(startDate))}\n")
-            appendLine("DTEND:${icsDateTimeFormat.format(Date(endDate))}\n")
+            appendLine("DTSTART:${icsDateTimeFormat.format(Date(startDate))}")
+            appendLine("DTEND:${icsDateTimeFormat.format(Date(endDate))}")
         }
 
-        title?.let { appendLine(foldLine("SUMMARY:${escape(it)}\n")) }
-        description?.let { appendLine(foldLine("DESCRIPTION:${escape(it)}\n")) }
-        location?.let { appendLine(foldLine("LOCATION:${escape(it)}\n")) }
+        title?.let { append(foldLine("SUMMARY:${escape(it)}")) }
+        description?.let { append(foldLine("DESCRIPTION:${escape(it)}")) }
+        location?.let { append(foldLine("LOCATION:${escape(it)}")) }
 
         reminders?.forEach { minutes ->
-            appendLine("BEGIN:VALARM\n")
-            appendLine("TRIGGER:-PT${minutes}M\n")
-            appendLine("ACTION:DISPLAY\n")
-            appendLine("END:VALARM\n")
+            appendLine("BEGIN:VALARM")
+            appendLine("TRIGGER:-PT${minutes}M")
+            appendLine("ACTION:DISPLAY")
+            appendLine("END:VALARM")
         }
 
-        appendLine("END:VEVENT\n")
+        appendLine("END:VEVENT")
         appendLine("END:VCALENDAR")
     }.toString()
 

--- a/android/src/test/kotlin/sncf/connect/tech/eventide/IcsEventManagerTest.kt
+++ b/android/src/test/kotlin/sncf/connect/tech/eventide/IcsEventManagerTest.kt
@@ -34,9 +34,30 @@ class IcsEventManagerTest {
             isAllDay = false
         )
 
-        val lines = icsContent.lines()
+        val lines = icsContent.split("\r\n").dropLast(1) // drop trailing empty string after final CRLF
         val blankLines = lines.filter { it.isBlank() }
         assertTrue(blankLines.isEmpty(), "ICS content must not contain blank lines (RFC 5545), found ${blankLines.size}")
+    }
+
+    @Test
+    fun `generateIcsContent uses CRLF line endings`() {
+        val icsContent = icsEventManager.generateIcsContent(
+            title = "Event",
+            description = "Desc",
+            location = "Paris",
+            startDate = 1700000000000L,
+            endDate = 1700003600000L,
+            reminders = listOf(10L),
+            isAllDay = false
+        )
+
+        assertTrue(!icsContent.contains("\r\n\r\n"), "ICS content must not contain blank lines")
+        val lines = icsContent.split("\r\n").dropLast(1)
+        assertTrue(lines.isNotEmpty(), "ICS content must contain CRLF-terminated lines")
+        assertTrue(
+            !icsContent.replace("\r\n", "").contains("\n"),
+            "ICS content must use CRLF line endings only (RFC 5545), no bare LF allowed"
+        )
     }
 
     @Test

--- a/android/src/test/kotlin/sncf/connect/tech/eventide/IcsEventManagerTest.kt
+++ b/android/src/test/kotlin/sncf/connect/tech/eventide/IcsEventManagerTest.kt
@@ -23,6 +23,23 @@ class IcsEventManagerTest {
     }
 
     @Test
+    fun `generateIcsContent contains no blank lines`() {
+        val icsContent = icsEventManager.generateIcsContent(
+            title = "Event",
+            description = "Desc",
+            location = "Paris",
+            startDate = 1700000000000L,
+            endDate = 1700003600000L,
+            reminders = listOf(10L),
+            isAllDay = false
+        )
+
+        val lines = icsContent.lines()
+        val blankLines = lines.filter { it.isBlank() }
+        assertTrue(blankLines.isEmpty(), "ICS content must not contain blank lines (RFC 5545), found ${blankLines.size}")
+    }
+
+    @Test
     fun `generateIcsContent with all fields filled and reminders`() {
         val icsContent = icsEventManager.generateIcsContent(
             title = "Réunion importante",


### PR DESCRIPTION
## Root cause
IcsEventManager.generateIcsContent had three RFC 5545 violations :

1. Lignes vides parasites
appendLine("BEGIN:VCALENDAR\n") — le \n embarqué combiné au \n d'appendLine produisait une ligne vide après chaque propriété, invalide selon la RFC :

| BEGIN:VCALENDAR | |
| -- | -- |
| |                  ← ligne vide invalide |
| VERSION:2.0 | |
| |                  ← ligne vide invalide |

2. Triple terminaison de ligne sur les champs pliés
appendLine(foldLine("SUMMARY:...\n")) produisait SUMMARY:...\n\r\n\n car foldLine ajoute déjà \r\n.

3. Fins de ligne incorrectes
appendLine produit des \n (Unix), alors que RFC 5545 §3.1 impose des \r\n (CRLF) sur toutes les lignes sans exception.

4. Folding on characters instead of bytes
foldLine was splitting on 75 characters, while RFC 5545 §3.1 defines the limit as 75 octets. A title or description containing non-ASCII characters (e.g. accents, emojis) can exceed 75 bytes with fewer than 75 characters in UTF-8 (é = 2 bytes, 🚂 = 4 bytes), causing strict parsers to reject the line.

## Fix
Suppression des \n embarqués dans les littéraux
Remplacement de appendLine(foldLine(...)) par append(foldLine(...))
Remplacement de tous les appendLine par une extension locale crlf() qui émet explicitement \r\n